### PR TITLE
Authentication scheme for updating specific groups/assets in metrics labels.

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,3 @@
+# Comma separated list of string tokens to be used if attempting to update
+# detection metrics for specific groups/assets. See README.
+AUTHORIZED_BEARER_TOKENS=""

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 outputs/
 docker_outputs/
 .envrc
+.env

--- a/README.md
+++ b/README.md
@@ -64,3 +64,51 @@ Run YOLOv8 test:
 ```shell
 python ./test/yolov8_loop.py
 ```
+
+## Authentication for Customized Metrics
+
+There is an optional feature of the API to allow for tracking its detection
+metrics against specific `groups` and `assets`.
+
+*   An `asset` is any device that provides the imagery that is used as input to
+    the API. For example: a camera pointing at a beach on Oak Island may be
+    referred to with its asset name `oakisland_east`.
+*   A `group` is an owning organization or operating organization responsible
+    for said asset. This could be an academic institution, a business, etc. For
+    the Oak Island, the device could be owned by the University of North
+    Carolina, Wilmington (UNCW), and its group name could be `uncw`.
+
+By default, the API will track all metrics against the group `any`, and the
+asset `any`. Example metrics stanza:
+
+```
+object_classification_detection_counter_total{asset="any",classification_name="sports ball",group="any",model_framework="sahi",model_name="yolo",model_version="v8n"} 0.0
+object_classification_detection_counter_total{asset="any",classification_name="kite",group="any",model_framework="sahi",model_name="yolo",model_version="v8n"} 0.0
+object_classification_detection_counter_total{asset="any",classification_name="surfboard",group="any",model_framework="sahi",model_name="yolo",model_version="v8n"} 0.0
+```
+
+
+To specify a `group` and `asset` to be calculated apart from the catch-all
+`any`, you must included the following headers in your endpoint requests:
+
+```
+Authorization: Bearer [token]
+x-axds-group: [group]
+x-axds-asset: [asset]
+```
+
+The authorization `[token]` must be provided by API administrators. Without an
+authorization token, the object detection request will fail.
+
+If you have an authorization token, you will be able to submit requests for
+object detections, and any successful detections against your requested `group`
+and `asset` will be counted in their own metric labels (in addition to be
+counted against the `any`/`any` catch-all labels).
+
+Example:
+
+```
+object_classification_detection_counter_total{asset="oakisland_west",classification_name="umbrella",group="uncw",model_framework="sahi",model_name="yolo",model_version="v8n"} 1.0
+object_classification_detection_counter_total{asset="oakisland_west",classification_name="person",group="uncw",model_framework="sahi",model_name="yolo",model_version="v8n"} 1.0
+object_classification_detection_counter_total{asset="oakisland_east",classification_name="person",group="uncw",model_framework="sahi",model_name="yolo",model_version="v8n"} 1.0
+```

--- a/api.py
+++ b/api.py
@@ -130,7 +130,9 @@ def yolo_from_upload(
         model,
         version,
         name,
-        bytedata
+        bytedata,
+        confidence_threshold,
+        cls_names_valid
     )
 
     if( res_path is None ):

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,118 @@
+
+import os
+import logging
+from typing import Annotated
+from fastapi import Depends, Header
+from fastapi.security import APIKeyHeader
+from fastapi.security.utils import get_authorization_scheme_param
+from fastapi.exceptions import HTTPException
+from dataclasses import dataclass
+
+
+@dataclass
+class TokenGroupAssetTuple:
+    token:  str
+    group:  str
+    asset:  str
+
+
+logger = logging.getLogger( __name__ )
+
+# Auth / token schemes
+authorization_token_scheme = APIKeyHeader(
+    name='Authorization',
+    auto_error=False
+)
+
+# Attempt to read and parse allowed bearer tokens from the
+# AUTHORIZED_BEARER_TOKENS environment variable.
+AUTHORIZED_BEARER_TOKENS = os.environ.get(
+    "AUTHORIZED_BEARER_TOKENS",
+    None
+)
+
+if AUTHORIZED_BEARER_TOKENS and isinstance( AUTHORIZED_BEARER_TOKENS, str ):
+
+    AUTHORIZED_BEARER_TOKENS = list( [
+        str( x ).strip().lower()
+        for x in AUTHORIZED_BEARER_TOKENS.split(",")
+        if str( x ).strip().lower()
+    ] )
+
+else:
+    AUTHORIZED_BEARER_TOKENS = []
+
+if not AUTHORIZED_BEARER_TOKENS:
+    logger.warning(
+        "AUTHORIZED_BEARER_TOKENS is unset/empty, this will disable any "
+        "group/asset-specific metrics from being recorded"
+    )
+
+def get_token_group_asset_tuple(
+    authorization: Annotated[str, Depends( authorization_token_scheme )],
+    x_axds_group: Annotated[str, Header()] = None,
+    x_axds_asset: Annotated[str, Header()] = None,
+):
+    token = None
+    group = None
+    asset = None
+
+    if authorization and isinstance( authorization, str ):
+
+        ( bearer, _token ) = get_authorization_scheme_param( authorization )
+
+        if bearer.lower() != 'bearer':
+            raise HTTPException(
+                400,
+                "Authorization header must be of format 'Bearer [token]'"
+            )
+
+        if _token:
+            token = _token
+
+    if (
+        x_axds_group and
+        isinstance( x_axds_group, str )
+     ):
+        group = x_axds_group
+
+    if (
+        x_axds_asset and
+        isinstance( x_axds_asset, str )
+     ):
+        asset = x_axds_asset
+
+    return TokenGroupAssetTuple(
+        token,
+        group,
+        asset
+    )
+
+def assert_auth_token_group_and_asset( tga: TokenGroupAssetTuple ):
+
+    assert tga is not None and isinstance( tga, TokenGroupAssetTuple )
+
+    if tga.group and tga.asset:
+
+        if not tga.token:
+
+            raise HTTPException(
+                403,
+                (
+                    "group/asset headers sent, but no authorization sent"
+                )
+            )
+
+        _token = str( tga.token ).strip().lower()
+
+        if _token not in AUTHORIZED_BEARER_TOKENS:
+
+            raise HTTPException(
+                403,
+                (
+                    "authorization/group/asset headers sent, but token not "
+                    "recognized"
+                )
+            )
+
+    return

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
      - "/outputs"
     environment:
      - OUTPUT_DIRECTORY=/outputs
+     - AUTHORIZED_BEARER_TOKENS
     command: >
       gunicorn api:app
         --bind "0.0.0.0:8000"

--- a/metrics.py
+++ b/metrics.py
@@ -12,6 +12,8 @@ from model_version import (
     YOLOModelObjectClassification
 )
 
+ANY="any"
+
 
 OBJECT_CLASSIFICATION_DETECTION_COUNTER = Counter(
     'object_classification_detection_counter',
@@ -21,6 +23,8 @@ OBJECT_CLASSIFICATION_DETECTION_COUNTER = Counter(
         'model_name',
         'model_version',
         'classification_name',
+        'group',
+        'asset',
     ]
 )
 
@@ -32,6 +36,8 @@ OBJECT_CLASSIFICATION_OBJECT_COUNTER = Counter(
         'model_name',
         'model_version',
         'classification_name',
+        'group',
+        'asset',
     ]
 )
 
@@ -59,12 +65,17 @@ LABELS = [
 ]
 
 for ( fw, mdl, ver, cls_name ) in LABELS:
+
     # Initialize counters
+
     OBJECT_CLASSIFICATION_DETECTION_COUNTER.labels(
         fw.name,
         mdl.value,
         ver.value,
         cls_name,
+        # unknown group/asset
+        ANY,
+        ANY
     )
 
     OBJECT_CLASSIFICATION_OBJECT_COUNTER.labels(
@@ -72,6 +83,9 @@ for ( fw, mdl, ver, cls_name ) in LABELS:
         mdl.value,
         ver.value,
         cls_name,
+        # unknown group/asset
+        ANY,
+        ANY
     )
 
 
@@ -85,13 +99,27 @@ def increment_detection_counter(
     fw: str,
     mdl_name: str,
     mdl_version: str,
-    cls_name: str
+    cls_name: str,
+    group: str = None,
+    asset: str = None,
 ):
+    if group and asset:
+        OBJECT_CLASSIFICATION_DETECTION_COUNTER.labels(
+            fw,
+            mdl_name,
+            mdl_version,
+            cls_name,
+            group,
+            asset
+        ).inc()
+
     OBJECT_CLASSIFICATION_DETECTION_COUNTER.labels(
         fw,
         mdl_name,
         mdl_version,
-        cls_name
+        cls_name,
+        ANY,
+        ANY
     ).inc()
 
 
@@ -99,11 +127,25 @@ def increment_object_counter(
     fw: str,
     mdl_name: str,
     mdl_version: str,
-    cls_name: str
+    cls_name: str,
+    group: str = None,
+    asset: str = None,
 ):
+    if group and asset:
+        OBJECT_CLASSIFICATION_OBJECT_COUNTER.labels(
+            fw,
+            mdl_name,
+            mdl_version,
+            cls_name,
+            group,
+            asset
+        ).inc()
+
     OBJECT_CLASSIFICATION_OBJECT_COUNTER.labels(
         fw,
         mdl_name,
         mdl_version,
-        cls_name
+        cls_name,
+        ANY,
+        ANY
     ).inc()

--- a/model_version.py
+++ b/model_version.py
@@ -59,7 +59,7 @@ class YOLOModelObjectClassification(str, Enum):
     # zebra = 'zebra'
     # giraffe = 'giraffe'
     # backpack = 'backpack'
-    # umbrella = 'umbrella'
+    umbrella = 'umbrella'
     # handbag = 'handbag'
     # tie = 'tie'
     # suitcase = 'suitcase'

--- a/namify.py
+++ b/namify.py
@@ -1,9 +1,10 @@
 
 import hashlib
+from typing import Tuple
 import filetype
 
 
-def namify_for_content( b: bytes ) -> ( str, str, ):
+def namify_for_content( b: bytes ) -> Tuple[str, str]:
 
     assert b
 

--- a/sahi_processing.py
+++ b/sahi_processing.py
@@ -54,6 +54,8 @@ def sahi_process_image(
     confidence_threshold: float = None,
     slice_size: Union[SAHISliceSize, int] = SAHISliceSize.slice_512,
     cls_names_valid: List[YOLOModelObjectClassification] = None,
+    group: str = None,
+    asset: str = None,
 ):
 
     assert yolo_model, \
@@ -216,7 +218,9 @@ def sahi_process_image(
                 ModelFramework.sahi.name,
                 model,
                 version,
-                yolo_object_class.value
+                yolo_object_class.value,
+                group,
+                asset,
             )
 
             # Track which of the object classes were detected for later
@@ -239,7 +243,9 @@ def sahi_process_image(
                     ModelFramework.sahi.name,
                     model,
                     version,
-                    ocd.value
+                    ocd.value,
+                    group,
+                    asset,
                 )
 
         output_file.parent.mkdir(parents=True, exist_ok=True)

--- a/yolo_processing.py
+++ b/yolo_processing.py
@@ -57,6 +57,8 @@ def yolo_process_image(
     bytedata: bytes,
     confidence_threshold: float = None,
     cls_names_valid: List[YOLOModelObjectClassification] = None,
+    group: str = None,
+    asset: str = None,
 ):
 
     assert yolo_model, \
@@ -178,7 +180,9 @@ def yolo_process_image(
                     ModelFramework.ultralytics.name,
                     model,
                     version,
-                    yolo_object_class.value
+                    yolo_object_class.value,
+                    group,
+                    asset,
                 )
 
                 # Track which of the object classes were detected for later
@@ -201,7 +205,9 @@ def yolo_process_image(
                     ModelFramework.ultralytics.name,
                     model,
                     version,
-                    ocd.value
+                    ocd.value,
+                    group,
+                    asset,
                 )
 
         output_file.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Provide token authentication to allow for updating metrics for specific cameras (group + asset) rather than the service just counting 'any' successful detections.